### PR TITLE
GHL COVID19 cassette added to selection

### DIFF
--- a/app/src/main/assets/config.json
+++ b/app/src/main/assets/config.json
@@ -109,5 +109,17 @@
     "MIDDLE_LINE_NAME": "TestPt",
     "LINE_INTENSITY": 85,
     "CHECK_GLARE": false
+  },
+  "covid19-ghl": {
+    "REF_IMG": "covid19_ghl_ref_v1",
+    "VIEW_FINDER_SCALE": 0.6,
+    "RESULT_WINDOW_TOP_LEFT": [302,71],
+    "RESULT_WINDOW_BOTTOM_RIGHT": [413,94],
+    "TOP_LINE_POSITION": [333,83],
+    "MIDDLE_LINE_POSITION": [384,83],
+    "TOP_LINE_NAME": "Control",
+    "MIDDLE_LINE_NAME": "Test",
+    "LINE_INTENSITY": 85,
+    "CHECK_GLARE": false
   }
 }

--- a/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/core/Constants.java
+++ b/app/src/main/java/edu/washington/cs/ubicomplab/rdt_reader/core/Constants.java
@@ -24,7 +24,7 @@ public final class Constants {
 
     // Default settings
     public static String LANGUAGE = "en";
-    public static final String DEFAULT_RDT_NAME = "malaria-carestart";
+    public static final String DEFAULT_RDT_NAME = "covid19-ghl";
     public static final String CONFIG_FILE_NAME = "config.json";
     public static final String DEFAULT_TOP_LINE_NAME = "Top Line Name";
     public static final String DEFAULT_MIDDLE_LINE_NAME = "Middle Line Name";

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="spinnerItems">
-        <item>covid19-jalmedical</item>
+        <item>covid19-ghl</item>
+        <item>malariapf-carestart</item>
+        <item>malaria-carestart</item>
+        <!--<item>covid19-jalmedical</item>
         <item>covid19-wondfo</item>
         <item>covid19-modified</item>
-        <item>malaria-carestart</item>
         <item>malaria-experimental</item>
         <item>malaria-sdbioline</item>
-        <item>flu-quickvue</item>
-        <item>malariapf-carestart</item>
+        <item>flu-quickvue</item>-->
     </string-array>
 </resources>


### PR DESCRIPTION
added the GHL COVID19 test cassette, reference image with QR codes, updated config.json and array.xml for Spinner
removed other cassettes except for Carestart from the Spinner
  in array.xml
         <item>covid19-ghl</item>
        <item>malariapf-carestart</item>
        <item>malaria-carestart</item>