### PR TITLE
Filename change  to GHT-rdtscan-<versionname>-<buildtype>.apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,13 +9,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 26
     defaultConfig {
         applicationId "edu.washington.cs.ubicomplab.rdt_reader"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        setProperty("archivesBaseName", "GHL-rdtscan-$versionName")
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -52,6 +53,6 @@ dependencies {
     //compile 'org.nd4j:nd4j-native:0.9.1:android-x86'
     //implementation project(':openCVLibrary341-contrib')
     implementation 'com.android.support:cardview-v7:26.1.0'
-    implementation 'com.android.support:exifinterface:25.1.0'
+    implementation 'com.android.support:exifinterface:26.1.0'
     implementation project(':openCVLibrary341-contrib')
 }


### PR DESCRIPTION
set filename to GHL-rdtscan-versionname-buildtype.apk, also changed target and compiled sdk to 26 to remove warnings